### PR TITLE
fix(auto-publish-tweet): set workflow to manual

### DIFF
--- a/.github/workflows/auto-publish-tweet.yml
+++ b/.github/workflows/auto-publish-tweet.yml
@@ -2,8 +2,6 @@ name: 'Tweeting on schrodinger_hat profile'
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 12 * * 1,4'
 
 jobs:
   upload_and_convert:


### PR DESCRIPTION
# Pull Request

## Description

No more publishing on sh twitter account and set as manual execution only

Fixes #132 
