### PR TITLE
feat: add 8sec on the polling call for finalising the conversion

### DIFF
--- a/src/ign-frontend/src/components/Demo.vue
+++ b/src/ign-frontend/src/components/Demo.vue
@@ -226,7 +226,7 @@ export default Vue.component('Demo', {
             } else if (jsonResponse.status === 'queued' || jsonResponse.status === 'started') {
               setTimeout(() => {
                 self.pollingAPI(jobId);
-              }, 800);
+              }, 8000);
             } else {
               document.querySelector('.preview').classList.toggle('processing');
               console.info('Something went wrong, please retry or write to us!');


### PR DESCRIPTION
# Pull Request

Closes #152 

We are doing a lot of polling requests when the avg conversion task it's going to finish in about 8sec.

Changing to 8sec from 0.8s