### PR TITLE
Grid Update for a more responsive and cleaner aproach

### DIFF
--- a/src/ign-frontend/src/views/GoWild.vue
+++ b/src/ign-frontend/src/views/GoWild.vue
@@ -254,6 +254,7 @@ export default {
     &:hover, &:focus, &:active, &.current-palette {
       border-color: $nord12;
       .palette-img {
+        -webkit-filter: brightness(0.6) blur(0);
         filter: brightness(0.6) blur(0);
       }
     }
@@ -271,6 +272,7 @@ export default {
       aspect-ratio: 4/3;
       object-fit: cover;
       background-size: cover;
+      -webkit-filter: brightness(0.3) blur(2px);
       filter: brightness(0.3) blur(2px);
       overflow: hidden;
     }

--- a/src/ign-frontend/src/views/GoWild.vue
+++ b/src/ign-frontend/src/views/GoWild.vue
@@ -262,6 +262,7 @@ export default {
       font-size: 25px;
       text-align: center;
       font-weight: bold;
+      color: $nord4;
       position: absolute;
     }
 

--- a/src/ign-frontend/src/views/GoWild.vue
+++ b/src/ign-frontend/src/views/GoWild.vue
@@ -58,9 +58,8 @@
       </center>
       <div class="palette-grid container">
         <div @click="selectedPalette = palette.file" :class="{'palette-post': true, 'current-palette': (selectedPalette === palette.file)}" v-for="palette in palettes" :key="palette.name">
-          <div :style="`width: 100%; background-position: center; background-size: cover; object-fit: cover; background-image: url(${require('../assets/' + palette.img)})`">
-            <span class="palette-title">{{ palette.name }}</span>
-          </div>
+          <div class="palette-img" :style="`background-image: url(${require('../assets/' + palette.img)})`"/>
+          <span class="palette-title">{{ palette.name }}</span>
         </div>
       </div>
       <br/>
@@ -239,42 +238,42 @@ export default {
 }
 
 .palette-grid {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-around;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-gap: 1em;
+  box-sizing: border-box;
+  padding: 0 1em;
 
   .palette-post {
     display: flex;
-    text-align: center;
-    width: 100%;
-    margin: 15px 10px;
-    flex: auto;
+    justify-content: center;
+    align-items: center;
+    position: relative;
     border: 8px solid transparent;
-
+    cursor: pointer;
     &:hover, &:focus, &:active, &.current-palette {
       border-color: $nord12;
-      cursor: pointer;
+      .palette-img {
+        filter: brightness(0.6) blur(0);
+      }
     }
 
     .palette-title {
       font-size: 25px;
       text-align: center;
-      width: calc(100% - 16px);
-      padding-top: 5em;
-      height: 6em;
-      color: $nord6;
-      background: #757575c9;
       font-weight: bold;
-      display: block;
+      position: absolute;
     }
 
-    img {
-      max-width: 100%;
-      max-height: 215px;
-      border: 6px solid $nord4;
-      border-radius: 5px;
+    .palette-img {
+      width: 100%;
+      aspect-ratio: 4/3;
+      object-fit: cover;
+      background-size: cover;
+      filter: brightness(0.3) blur(2px);
+      overflow: hidden;
     }
+
   }
 }
 
@@ -290,27 +289,6 @@ export default {
         margin-top: 4em;
       }
     }
-  }
-  .palette-grid {
-    .palette-post {
-      display: inline-flex;
-      width: 30%;
-      margin: 15px 10px;
-      flex: auto;
-    }
-    .palette-title {
-      font-size: 25px;
-      text-align: center;
-      width: calc(100% - 16px);
-      padding-top: 5em;
-      height: 6em;
-      color: $nord6;
-      background: #757575c9;
-      font-weight: bold;
-      display: block;
-      border: 8px solid transparent;
-    }
-
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

ImageGoWild palette **grid** update for a more responsive and cleaner aproach

### Bug fixes 🐛

Before was a little bug with mobile devices when using the width: calc(100% - 16px) on line 263 inside GoWild.vue, now works and looks fine on Desktop and Mobile devices.

Also the aspect ratio was dynamic, causing some times to have cards too much wide for the background image to show properly. Now the aspect-ratio is fixed (4/3) that works great with the majority of modern images. 

### Fancy Stuff ✨

Now the non focus/selected cards are dim and blur.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
